### PR TITLE
Remove redundant to_s call

### DIFF
--- a/lib/flash-message-conductor/controller_helpers.rb
+++ b/lib/flash-message-conductor/controller_helpers.rb
@@ -5,7 +5,7 @@ module FlashMessageConductor
     module ClassMethods
     end
     FLASH_MESSAGE_TYPES.each do |message_type|
-      define_method("add_#{message_type.to_s}") do |message, *options|
+      define_method("add_#{message_type}") do |message, *options|
         options = options.first || Hash.new
 
         flash[message_type] = message


### PR DESCRIPTION
This is already interpolated inside of a string, so the `to_s` call is redundant
